### PR TITLE
Fixing a couple issues with attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/*
 MANIFEST
 dist/*
+*.egg-info/

--- a/doc/ComplexMessage.rst
+++ b/doc/ComplexMessage.rst
@@ -100,11 +100,13 @@ EmojiAttach
 ===========
 
 GroupMe has extended emoji with GroupMe specific "packs" that can be used in the app. This attachment will encode a single emoji from
-their extended set. It takes a single ``pack_id`` parameter encoded as an int. This feature depends on an invisible
-character (``\u200B`` is used by this library) being present in the message and swapping it out client-side with the Emoji given by ``pack_id``. For example::
+their extended set. It takes a two int parameters - ``pack_id`` and ``emoji_id``, where ``pack_id`` is the ID of the pack of emojis,
+and ``emoji_id`` is the ID of the emoji within the given pack. This feature depends on an invisible
+character (``\ufffd`` is used by this library) being present in the message and swapping it out client-side with the Emoji given by the ``(pack_id, emoji_id)`` pair.
+For example::
 
-    message = 'Hope everyone is doing alright' + EmojiAttach(1)
+    message = 'Hope everyone is doing alright' + EmojiAttach(1, 1)
 
-    message.get_text() == 'Hope everyone is doing alright\u200B'
-    message.get_attachments() == [EmojiAttach(1)]
+    message.get_text() == 'Hope everyone is doing alright\ufffd'
+    message.get_attachments() == [EmojiAttach(1, 1)]
 

--- a/lowerpines/message.py
+++ b/lowerpines/message.py
@@ -73,12 +73,13 @@ class SplitAttach(MessageAttach):
         return 'S:' + str(self)
 
 
-EMOJI_PLACEHOLDER = '\u200B'
+EMOJI_PLACEHOLDER = '\ufffd'
 
 
 class EmojiAttach(MessageAttach):
-    def __init__(self, pack_id):
+    def __init__(self, pack_id, emoji_id):
         self.pack_id = pack_id
+        self.emoji_id = emoji_id
 
     def __str__(self):
         return EMOJI_PLACEHOLDER
@@ -151,7 +152,7 @@ class ComplexMessage:
                     'token': part.token
                 })
             elif isinstance(part, EmojiAttach):
-                emojis['charmap'].append([part.pack_id, len(content_frag)])
+                emojis['charmap'].append([part.pack_id, part.emoji_id])
                 if emojis not in attach_list:
                     attach_list.append(emojis)
             content_frag += str(part)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     packages=['lowerpines', 'lowerpines.endpoints'],
     version=lowerpines.VERSION,
     description='Library wrapper for GroupMe API',
-    requires=['requests'],
+    install_requires=['requests'],
     license='GNU Lesser General Public License v3 (LGPLv3)',
     author='Jonathan Janzen',
     author_email='jjjonjanzen@gmail.com',

--- a/test/test_complex_message.py
+++ b/test/test_complex_message.py
@@ -56,8 +56,8 @@ class SmartSplitComplexMessage(TestCase):
 class MessageAttachTest(TestCase):
     def test_mixing_together(self):
         message = RefAttach('user1') + ImageAttach('http://image.url') + LocationAttach('home', 32, 83) + SplitAttach(
-            'token') + EmojiAttach(13)
-        self.assertEqual(message.get_text(), 'hometoken\u200b')
+            'token') + EmojiAttach(13, 9)
+        self.assertEqual(message.get_text(), 'hometoken\ufffd')
         self.assertEqual(message.get_attachments(), [
             {
                 'type': 'mentions',
@@ -81,7 +81,7 @@ class MessageAttachTest(TestCase):
             {
                 'type': 'emoji',
                 'charmap': [[13, 9]],
-                'placeholder': '\u200b',
+                'placeholder': '\ufffd',
             }
         ])
 


### PR DESCRIPTION
Hey there, I fixed a couple issues I came across with attachments.

* The current EMOJI_PLACEHOLDER works in the web browser, but not in the iPhone app.  For some reason the iPhone app only seems to like `'\ufffd'`.
* The second part of each entry in the emoji charmap should be the emoji_id within the pack, not the offset from the beginning of the text.