### PR TITLE
Fixed bug in image service response parsing

### DIFF
--- a/lowerpines/endpoints/image.py
+++ b/lowerpines/endpoints/image.py
@@ -18,3 +18,6 @@ class ImageConvertRequest(Request):
     def parse(self, response):
         return response['payload']['url']
 
+    def extract_response(self, response):
+        return response.json()
+

--- a/lowerpines/endpoints/request.py
+++ b/lowerpines/endpoints/request.py
@@ -41,7 +41,7 @@ class Request:
         if r.content.decode('utf-8').isspace():
             return None
         else:
-            return r.json()["response"]
+            return self.extract_response(r)
 
     def error_check(self, request):
         code = int(request.status_code)
@@ -53,3 +53,6 @@ class Request:
                 text = '(TEXT): ' + str(request.text)
             raise GroupMeApiException('Something has gone wrong ' + text + ' for ' + str(self.mode()) + ' ' + str(
                 self.url()) + ' with data:\n' + str(self.args()))
+
+    def extract_response(self, response):
+        return response.json()["response"]


### PR DESCRIPTION
For the other API requests, it seems that GroupMe wraps the responses in a "response" envelope that needs to be extracted with the `r.json()["response"]`. But, the Image Service doesn't seem to follow the same pattern: https://dev.groupme.com/docs/image_service . I've tested it with the framework, (in which i received a KeyError on "response") and  with cURL as detailed in the Image Service Guide, in which I received: 
```
{"payload":
  {
    "url":"https://i.groupme.com/950x713.jpeg.5b8eb43abd4942d891be1787902d9183",
    "picture_url":"https://i.groupme.com/950x713.jpeg.5b8eb43abd4942d891be1787902d9183"
  }
}
```
The rest of the API is documented on the general API page: https://dev.groupme.com/docs/v3 , which at the top says that the requests are enveloped by the `"request": {` pattern, so I think that the Image Service is the only exception. 