### PR TITLE
Handle empty response bodies

### DIFF
--- a/lowerpines/endpoints/request.py
+++ b/lowerpines/endpoints/request.py
@@ -73,7 +73,8 @@ class Request(Generic[T]):
         else:
             raise InvalidOperationException()
         self.error_check(r)
-        if r.content.decode("utf-8").isspace():
+        string_content = r.content.decode("utf-8")
+        if not string_content or string_content.isspace():
             return None
         else:
             return self.extract_response(r)


### PR DESCRIPTION
Apparently the groupme API has started returning empty response bodies for bot posts, so this change should be able to handle those responses appropriately now.